### PR TITLE
Fixes Ruby 2.0 Net::HTTP gzip related bug

### DIFF
--- a/lib/fastimage.rb
+++ b/lib/fastimage.rb
@@ -184,7 +184,7 @@ class FastImage
   
   def fetch_using_http_from_parsed_uri
     setup_http
-    @http.request_get(@parsed_uri.request_uri) do |res|
+    @http.request_get(@parsed_uri.request_uri, 'Accept-Encoding' => 'identity') do |res|
       if res.is_a?(Net::HTTPRedirection) && @redirect_count < 4
         @redirect_count += 1
         begin


### PR DESCRIPTION
see 
- https://github.com/sparklemotion/mechanize/issues/275, 
  - https://bugs.ruby-lang.org/issues/7831 
  - http://ruby-doc.org/stdlib-2.0/libdoc/net/http/rdoc/Net/HTTP.html#label-Compression
