### PR TITLE
Switched to using Addressable for URI parsing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,1 @@
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,17 @@
+PATH
+  remote: .
+  specs:
+    fastimage (1.5.2)
+      addressable (~> 2.3.5)
+
+GEM
+  specs:
+    addressable (2.3.5)
+    fakeweb (1.3.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  fakeweb (~> 1.3.0)
+  fastimage!

--- a/README.textile
+++ b/README.textile
@@ -16,7 +16,7 @@ You only need supply the uri, and FastImage will do the rest.
 
 h2. Features
 
-Fastimage can also read local (and other) files, and uses the open-uri library to do so.
+Fastimage can also read local (and other) files, and uses the Addressable library to do so.
 
 FastImage will automatically read from any object that responds to :read - for
 instance an IO object if that is passed instead of a URI.

--- a/fastimage.gemspec
+++ b/fastimage.gemspec
@@ -35,6 +35,8 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.6}
   s.summary = %q{FastImage - Image info fast}
+  s.add_runtime_dependency 'addressable', '~> 2.3.5'
+  s.add_development_dependency 'fakeweb', '~> 1.3.0'
   s.test_files = [
     "test/test.rb"
   ]

--- a/lib/fastimage.rb
+++ b/lib/fastimage.rb
@@ -11,7 +11,7 @@
 # FastImage knows about GIF, JPEG, BMP, TIFF and PNG files.
 #
 # FastImage can also read files from the local filesystem by supplying the path instead of a uri.
-# In this case FastImage uses the open-uri library to read the file in chunks of 256 bytes until
+# In this case FastImage uses the Addressable library to read the file in chunks of 256 bytes until
 # it has enough. This is possibly a useful bandwidth-saving feature if the file is on a network
 # attached disk rather than truly local.
 #
@@ -41,7 +41,7 @@
 #
 
 require 'net/https'
-require 'open-uri'
+require 'addressable/uri'
 require 'fastimage/fbr.rb'
 
 class FastImage
@@ -161,8 +161,8 @@ class FastImage
       fetch_using_read(uri)
     else
       begin
-        @parsed_uri = URI.parse(uri)
-      rescue URI::InvalidURIError
+        @parsed_uri = Addressable::URI.parse(uri)
+      rescue Addressable::URI::InvalidURIError
         fetch_using_open_uri
       else
         if @parsed_uri.scheme == "http" || @parsed_uri.scheme == "https"
@@ -209,14 +209,14 @@ class FastImage
       if res.is_a?(Net::HTTPRedirection) && @redirect_count < 4
         @redirect_count += 1
         begin
-          newly_parsed_uri = URI.parse(res['Location'])
+          newly_parsed_uri = Addressable::URI.parse(res['Location'])
           # The new location may be relative - check for that
           if newly_parsed_uri.scheme != "http" && newly_parsed_uri.scheme != "https"
             @parsed_uri.path = res['Location']
           else
             @parsed_uri = newly_parsed_uri
           end
-        rescue URI::InvalidURIError
+        rescue Addressable::URI::InvalidURIError
         else
           fetch_using_http_from_parsed_uri
           break
@@ -239,8 +239,8 @@ class FastImage
 
   def proxy_uri
     begin
-      proxy = ENV['http_proxy'] && ENV['http_proxy'] != "" ? URI.parse(ENV['http_proxy']) : nil
-    rescue URI::InvalidURIError
+      proxy = ENV['http_proxy'] && ENV['http_proxy'] != "" ? Addressable::URI.parse(ENV['http_proxy']) : nil
+    rescue Addressable::URI::InvalidURIError
       proxy = nil
     end
     proxy


### PR DESCRIPTION
Due to issues with hostnames that contain underscores. This was causing a lot of image load failures on CDNs that don't conform exactly to the RFC.

http://www.cloudspace.com/blog/2009/05/26/replacing-rubys-uri-with-addressable/
