### PR TITLE
Replace recursion with iteration and other refactorings

### DIFF
--- a/lib/fastimage.rb
+++ b/lib/fastimage.rb
@@ -241,12 +241,9 @@ class FastImage
   end
 
   def proxy_uri
-    begin
-      proxy = ENV['http_proxy'] && ENV['http_proxy'] != "" ? Addressable::URI.parse(ENV['http_proxy']) : nil
-    rescue Addressable::URI::InvalidURIError
-      proxy = nil
-    end
-    proxy
+    ENV['http_proxy'] != "" ? Addressable::URI.parse(ENV['http_proxy']) : nil
+  rescue Addressable::URI::InvalidURIError
+    nil
   end
 
   def setup_http

--- a/lib/fastimage.rb
+++ b/lib/fastimage.rb
@@ -217,7 +217,7 @@ class FastImage
       @http.request_get(@parsed_uri.request_uri, 'Accept-Encoding' => 'identity') do |res|
         if res.is_a?(Net::HTTPRedirection) && redirect_count < 4
           redirect_count += 1
-          get_new_uri_from(res['Location'])
+          raise ImageFetchFailure unless get_new_uri_from(res['Location'])
         elsif res.is_a?(Net::HTTPSuccess)
           read_fiber = Fiber.new do
             res.read_body do |str|
@@ -243,7 +243,7 @@ class FastImage
       @parsed_uri.path = location
     end
   rescue Addressable::URI::InvalidURIError
-    raise ImageFetchFailure
+    nil
   end
 
   def proxy_uri

--- a/lib/fastimage.rb
+++ b/lib/fastimage.rb
@@ -168,7 +168,7 @@ class FastImage
       rescue Addressable::URI::InvalidURIError
         fetch_using_open_uri
       else
-        if @parsed_uri.scheme == "http" || @parsed_uri.scheme == "https"
+        if @parsed_uri.scheme =~ /^https?$/
           fetch_using_http
         else
           fetch_using_open_uri
@@ -214,10 +214,10 @@ class FastImage
         begin
           newly_parsed_uri = Addressable::URI.parse(res['Location'])
           # The new location may be relative - check for that
-          if newly_parsed_uri.scheme != "http" && newly_parsed_uri.scheme != "https"
-            @parsed_uri.path = res['Location']
-          else
+          if newly_parsed_uri.scheme =~ /^https?$/
             @parsed_uri = newly_parsed_uri
+          else
+            @parsed_uri.path = res['Location']
           end
         rescue Addressable::URI::InvalidURIError
         else

--- a/lib/fastimage.rb
+++ b/lib/fastimage.rb
@@ -203,6 +203,12 @@ class FastImage
   def fetch_using_http
     @redirect_count = 0
 
+    proxy = proxy_uri
+    @http_class = if proxy
+                    Net::HTTP::Proxy(proxy.host, proxy.port)
+                  else
+                    Net::HTTP
+                  end
     fetch_using_http_from_parsed_uri
   end
 
@@ -247,13 +253,7 @@ class FastImage
   end
 
   def setup_http
-    proxy = proxy_uri
-    http_class = if proxy
-                   Net::HTTP::Proxy(proxy.host, proxy.port)
-                 else
-                   Net::HTTP
-                 end
-    @http = http_class.new(@parsed_uri.host, @parsed_uri.inferred_port)
+    @http = @http_class.new(@parsed_uri.host, @parsed_uri.inferred_port)
     @http.use_ssl = (@parsed_uri.scheme == "https")
     @http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     @http.open_timeout = @timeout

--- a/lib/fastimage.rb
+++ b/lib/fastimage.rb
@@ -248,12 +248,12 @@ class FastImage
 
   def setup_http
     proxy = proxy_uri
-
-    if proxy
-      @http = Net::HTTP::Proxy(proxy.host, proxy.port).new(@parsed_uri.host, @parsed_uri.inferred_port)
-    else
-      @http = Net::HTTP.new(@parsed_uri.host, @parsed_uri.inferred_port)
-    end
+    http_class = if proxy
+                   Net::HTTP::Proxy(proxy.host, proxy.port)
+                 else
+                   Net::HTTP
+                 end
+    @http = http_class.new(@parsed_uri.host, @parsed_uri.inferred_port)
     @http.use_ssl = (@parsed_uri.scheme == "https")
     @http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     @http.open_timeout = @timeout


### PR DESCRIPTION
At RailCconf, DHH incentivized programmers to read through a complete gem. I had been using this gem for so long and yet I had never looked into its code that I decided to do it today.

One method that I couldn't wrap my head around was `fetch_using_http_from_parsed_uri`, mainly because of its use of recursion. I decided to replace that with iteration and through this exercise, I ended up making a few other changes.

There are a few things I don't like about this refactoring:
- I introduced a new instance variable (`@http_class`) but on the upside I removed another (`@redirect_count`)
- The variable `@http_class` is set in the `fetch_using_http` method which seems out of place.
- The error `ImageFetchFailure` is raised in two different places in the `fetch_using_http_from_parsed_uri` method.

However, overall, the code seems a little simpler (to me, at least).

I made sure to benchmark the new code (I mean, I certainly don't want to make a gem called fastimage any slower) and there weren't any noticeable changes.

I'm not sure if these changes are welcome or even warranted. I mean, "if it ain't broke, don't fix it". But I had a lot of fun doing this, and I don't see any harm in just showing what I accomplished through this refactoring exercise.
