### PR TITLE
Make dependency on addressable optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.2
-# uncomment this line if your project needs to run something other than `rake`:
-# script: bundle exec rspec spec
+# need to run in dev mode otherwise we will
+# not get addressable
+bundler_args: --retry=3 --jobs=3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     fastimage (1.6.6)
-      addressable (~> 2.3, >= 2.3.5)
 
 GEM
   remote: https://rubygems.org/
@@ -18,6 +17,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  addressable (~> 2.3, >= 2.3.5)
   fakeweb (~> 1.3)
   fastimage!
   rake

--- a/README.textile
+++ b/README.textile
@@ -18,7 +18,7 @@ You only need supply the uri, and FastImage will do the rest.
 
 h2. Features
 
-Fastimage can also read local (and other) files, and uses the Addressable library to do so.
+Fastimage can also read local (and other) files, and uses the open-uri library to do so.
 
 FastImage will automatically read from any object that responds to :read - for
 instance an IO object if that is passed instead of a URI.
@@ -30,6 +30,21 @@ FastImage will obey the http_proxy setting in your environment to route requests
 You can add a timeout to the request which will limit the request time by passing :timeout => number_of_seconds.
 
 FastImage normally replies will nil if it encounters an error, but you can pass :raise_on_failure => true to get an exception.
+
+You may optionally use the `addressable` gem for URI parsing or a custom URI parser.
+
+To use the `addressable` gem for uri parsing.
+
+<pre lang="ruby"><code>
+require 'addressable/uri'
+FastImage.use_addressable_uri_parser
+</code></pre>
+
+To use a custom URI parser like, for example, the old URI parser in Ruby 2.2 for example use:
+
+<pre lang="ruby"><code>
+FastImage.uri_parser =  URI::RFC2396_Parser.new
+</code></pre>
 
 h2. Examples
 

--- a/fastimage.gemspec
+++ b/fastimage.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.6}
   s.summary = %q{FastImage - Image info fast}
-  s.add_runtime_dependency 'addressable', '~> 2.3', '>= 2.3.5'
+  s.add_development_dependency 'addressable', '~> 2.3', '>= 2.3.5'
   s.add_development_dependency 'fakeweb', '~> 1.3'
   s.add_development_dependency('rake')
   s.add_development_dependency('rdoc')  

--- a/lib/fastimage.rb
+++ b/lib/fastimage.rb
@@ -364,7 +364,7 @@ class FastImage
         @strpos = 0
       end
 
-      result = @str[@strpos..(@strpos + n - 1)]
+      @str[@strpos..(@strpos + n - 1)]
     end
 
     def read(n)
@@ -456,7 +456,7 @@ class FastImage
         @stream.read(skip_chars)
         :started
       when :readsize
-        s = @stream.read(3)
+        _s = @stream.read(3)
         height = @stream.read_int
         width = @stream.read_int
         width, height = height, width if @exif && @exif.rotated?
@@ -481,7 +481,7 @@ class FastImage
 
   def parse_size_for_webp
     vp8 = @stream.read(16)[12..15]
-    len = @stream.read(4).unpack("V")
+    _len = @stream.read(4).unpack("V")
     case vp8
     when "VP8 "
       parse_size_vp8

--- a/lib/fastimage.rb
+++ b/lib/fastimage.rb
@@ -11,7 +11,7 @@
 # FastImage knows about GIF, JPEG, BMP, TIFF, ICO, CUR, PNG, PSD and WEBP files.
 #
 # FastImage can also read files from the local filesystem by supplying the path instead of a uri.
-# In this case FastImage uses the Addressable library to read the file in chunks of 256 bytes until
+# In this case FastImage uses the open-uri library to read the file in chunks of 256 bytes until
 # it has enough. This is possibly a useful bandwidth-saving feature if the file is on a network
 # attached disk rather than truly local.
 #
@@ -41,8 +41,8 @@
 #
 
 require 'net/https'
-require 'addressable/uri'
 require 'fastimage/fbr.rb'
+require 'open-uri'
 require 'delegate'
 require 'pathname'
 require 'zlib'
@@ -66,6 +66,28 @@ class FastImage
   DefaultTimeout = 2 unless const_defined?(:DefaultTimeout)
 
   LocalFileChunkSize = 256 unless const_defined?(:LocalFileChunkSize)
+
+  # Parser object should respond to #parse
+  # and raise a URI::InvalidURIError if something goes wrong
+  def self.uri_parser=(parser)
+    @uri_parser = parser
+  end
+
+  # Helper that sets URI parsing to use the Addressable gem
+  def self.use_addressable_uri_parser
+    require 'addressable/uri'
+    self.uri_parser = Class.new do
+      def self.parse(location)
+        Addressable::URI.parse(location)
+      rescue Addressable::URI::InvalidURIError
+        raise URI::InvalidURIError
+      end
+    end
+  end
+
+  def self.parse_uri(location)
+    (@uri_parser || URI).parse(location)
+  end
 
   # Returns an array containing the width and height of the image.
   # It will return nil if the image could not be fetched, or if the image type was not recognised.
@@ -166,8 +188,8 @@ class FastImage
       fetch_using_read(uri)
     else
       begin
-        @parsed_uri = Addressable::URI.parse(uri)
-      rescue Addressable::URI::InvalidURIError
+        @parsed_uri = self.class.parse_uri(uri)
+      rescue URI::InvalidURIError
         fetch_using_open_uri
       else
         if @parsed_uri.scheme == "http" || @parsed_uri.scheme == "https"
@@ -214,14 +236,14 @@ class FastImage
       if res.is_a?(Net::HTTPRedirection) && @redirect_count < 4
         @redirect_count += 1
         begin
-          newly_parsed_uri = Addressable::URI.parse(res['Location'])
+          newly_parsed_uri = self.class.parse_uri(res['Location'])
           # The new location may be relative - check for that
           if newly_parsed_uri.scheme != "http" && newly_parsed_uri.scheme != "https"
             @parsed_uri.path = res['Location']
           else
             @parsed_uri = newly_parsed_uri
           end
-        rescue Addressable::URI::InvalidURIError
+        rescue URI::InvalidURIError
         else
           fetch_using_http_from_parsed_uri
           break
@@ -259,8 +281,8 @@ class FastImage
 
   def proxy_uri
     begin
-      proxy = ENV['http_proxy'] && ENV['http_proxy'] != "" ? Addressable::URI.parse(ENV['http_proxy']) : nil
-    rescue Addressable::URI::InvalidURIError
+      proxy = ENV['http_proxy'] && ENV['http_proxy'] != "" ? self.class.parse_uri(ENV['http_proxy']) : nil
+    rescue URI::InvalidURIError
       proxy = nil
     end
     proxy
@@ -269,10 +291,13 @@ class FastImage
   def setup_http
     proxy = proxy_uri
 
+    port = @parsed_uri.port
+    port ||= @parsed_uri.scheme == "https" ? 443 : 80
+
     if proxy
-      @http = Net::HTTP::Proxy(proxy.host, proxy.port).new(@parsed_uri.host, @parsed_uri.inferred_port)
+      @http = Net::HTTP::Proxy(proxy.host, proxy.port).new(@parsed_uri.host, port)
     else
-      @http = Net::HTTP.new(@parsed_uri.host, @parsed_uri.inferred_port)
+      @http = Net::HTTP.new(@parsed_uri.host, port)
     end
     @http.use_ssl = (@parsed_uri.scheme == "https")
     @http.verify_mode = OpenSSL::SSL::VERIFY_NONE

--- a/test/test.rb
+++ b/test/test.rb
@@ -249,7 +249,7 @@ class FastImageTest < Test::Unit::TestCase
     size = FastImage.size(HTTPSImage)
     assert_equal HTTPSImageInfo[1], size
   end
-  
+
   require 'pathname'
   def test_should_handle_pathname
     # bad.jpg does not have the size info in the first 256 bytes
@@ -258,7 +258,7 @@ class FastImageTest < Test::Unit::TestCase
     path = Pathname.new(File.join(FixturePath, "bad.jpg"))
     assert_equal([500,500], FastImage.size(path))
   end
-  
+
   def test_should_report_type_and_size_correctly_for_stringios
     GoodFixtures.each do |fn, info|
       string = File.read(File.join(FixturePath, fn))
@@ -267,7 +267,7 @@ class FastImageTest < Test::Unit::TestCase
       assert_equal info[1], FastImage.size(stringio)
     end
   end
-  
+
   def test_gzipped_file
     url = "http://example.nowhere/#{GzipTestImg}"
     assert_equal([970, 450], FastImage.size(url))
@@ -279,4 +279,10 @@ class FastImageTest < Test::Unit::TestCase
       FastImage.size(url, :raise_on_failure => true)
     end
   end
+end
+
+
+# repeat all tests with addressable
+FastImage.use_addressable_uri_parser
+class FastImageTestAddressable < FastImageTest
 end


### PR DESCRIPTION
Make dependency on addressable optional, allow consumers to easily pick a uri parser
