### PR TITLE
add options[:proxy] as a per request proxy config

### DIFF
--- a/fastimage.gemspec
+++ b/fastimage.gemspec
@@ -49,7 +49,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'addressable', '~> 2.3', '>= 2.3.5'
   s.add_development_dependency 'fakeweb', '~> 1.3'
   s.add_development_dependency('rake')
-  s.add_development_dependency('rdoc')  
+  s.add_development_dependency('rdoc')
+  s.add_development_dependency('test-unit')
 
   s.test_files = [
     "test/test.rb"

--- a/lib/fastimage.rb
+++ b/lib/fastimage.rb
@@ -160,6 +160,7 @@ class FastImage
   def initialize(uri, options={})
     @property = options[:type_only] ? :type : :size
     @timeout = options[:timeout] || DefaultTimeout
+    @proxy_url = options[:proxy]
     @uri = uri
 
     if uri.respond_to?(:read)
@@ -259,7 +260,11 @@ class FastImage
 
   def proxy_uri
     begin
-      proxy = ENV['http_proxy'] && ENV['http_proxy'] != "" ? Addressable::URI.parse(ENV['http_proxy']) : nil
+      if @proxy_url
+        proxy = Addressable::URI.parse(@proxy_url)
+      else
+        proxy = ENV['http_proxy'] && ENV['http_proxy'] != "" ? Addressable::URI.parse(ENV['http_proxy']) : nil
+      end
     rescue Addressable::URI::InvalidURIError
       proxy = nil
     end

--- a/lib/fastimage.rb
+++ b/lib/fastimage.rb
@@ -250,7 +250,7 @@ class FastImage
           end
         end
       end
-      
+
       parse_packets FiberStream.new(read_fiber)
 
       break  # needed to actively quit out of the fetch
@@ -404,7 +404,7 @@ class FastImage
         :webp
       else
         raise UnknownImageType
-      end        
+      end
     else
       raise UnknownImageType
     end
@@ -493,18 +493,18 @@ class FastImage
       nil
     end
   end
-  
+
   def parse_size_vp8
     w, h = @stream.read(10).unpack("@6vv")
     [w & 0x3fff, h & 0x3fff]
   end
-  
+
   def parse_size_vp8l
     @stream.read(1) # 0x2f
     b1, b2, b3, b4 = @stream.read(4).bytes.to_a
     [1 + (((b2 & 0x3f) << 8) | b1), 1 + (((b4 & 0xF) << 10) | (b3 << 2) | ((b2 & 0xC0) >> 6))]
   end
-  
+
   def parse_size_vp8x
     flags = @stream.read(4).unpack("C")[0]
     b1, b2, b3, b4, b5, b6 = @stream.read(6).unpack("CCCCCC")
@@ -514,7 +514,7 @@ class FastImage
       # parse exif for orientation
       # TODO: find or create test images for this
     end
-    
+
     return [width, height]
   end
 

--- a/lib/fastimage/fbr.rb
+++ b/lib/fastimage/fbr.rb
@@ -64,4 +64,3 @@ unless defined? Fiber
     end
   end
 end
-

--- a/test/test.rb
+++ b/test/test.rb
@@ -60,9 +60,9 @@ BadFixtures.each do |fn|
 end
 
 GzipTestImg = "gzipped.jpg"
-FakeWeb.register_uri(:get, "#{TestUrl}#{GzipTestImg}", :body => File.join(FixturePath, GzipTestImg), :content_encoding => "gzip") 
+FakeWeb.register_uri(:get, "#{TestUrl}#{GzipTestImg}", :body => File.join(FixturePath, GzipTestImg), :content_encoding => "gzip")
 GzipTestImgTruncated = "truncated_gzipped.jpg"
-FakeWeb.register_uri(:get, "#{TestUrl}#{GzipTestImgTruncated}", :body => File.join(FixturePath, GzipTestImgTruncated), :content_encoding => "gzip") 
+FakeWeb.register_uri(:get, "#{TestUrl}#{GzipTestImgTruncated}", :body => File.join(FixturePath, GzipTestImgTruncated), :content_encoding => "gzip")
 GzipTestImgSize = [970, 450]
 
 class FastImageTest < Test::Unit::TestCase
@@ -249,7 +249,7 @@ class FastImageTest < Test::Unit::TestCase
     size = FastImage.size(HTTPSImage)
     assert_equal HTTPSImageInfo[1], size
   end
-  
+
   require 'pathname'
   def test_should_handle_pathname
     # bad.jpg does not have the size info in the first 256 bytes
@@ -258,7 +258,7 @@ class FastImageTest < Test::Unit::TestCase
     path = Pathname.new(File.join(FixturePath, "bad.jpg"))
     assert_equal([500,500], FastImage.size(path))
   end
-  
+
   def test_should_report_type_and_size_correctly_for_stringios
     GoodFixtures.each do |fn, info|
       string = File.read(File.join(FixturePath, fn))
@@ -267,7 +267,7 @@ class FastImageTest < Test::Unit::TestCase
       assert_equal info[1], FastImage.size(stringio)
     end
   end
-  
+
   def test_gzipped_file
     url = "http://example.nowhere/#{GzipTestImg}"
     assert_equal([970, 450], FastImage.size(url))
@@ -279,7 +279,7 @@ class FastImageTest < Test::Unit::TestCase
       FastImage.size(url, :raise_on_failure => true)
     end
   end
-  
+
   def test_cant_access_shell
     url = "|echo>shell_test"
     %x{rm -f shell_test}

--- a/test/test.rb
+++ b/test/test.rb
@@ -245,6 +245,13 @@ class FastImageTest < Test::Unit::TestCase
     assert_equal actual_size, size
   end
 
+  def test_should_fetch_via_proxy_option
+    file = "test.gif"
+    actual_size = GoodFixtures[file][1]
+    size = FastImage.size(TestUrl + file, proxy: "http://my.proxy.host:8080")
+    assert_equal actual_size, size
+  end
+
   def test_should_handle_https_image
     size = FastImage.size(HTTPSImage)
     assert_equal HTTPSImageInfo[1], size


### PR DESCRIPTION
Hi,

this patch add an per-request proxy option so we can easily do this

```ruby
FastImage.size("http://farm4.static.flickr.com/3023/3047236863_9dce98b836.jpg", proxy: 'http://my-proxy-host.com:7777')

FastImage.type("http://farm4.static.flickr.com/3023/3047236863_9dce98b836.jpg", proxy: 'http://my-proxy-host.com:7777')
```

Also maybe you should exclude `Gemfile.lock` from the repo?
