### PR TITLE
Add reader for request header content-length

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -51,6 +51,8 @@ FastImage.size("http://upload.wikimedia.org/wikipedia/commons/b/b4/Mardin_135066
 => FastImage::ImageFetchFailure: FastImage::ImageFetchFailure
 FastImage.size("http://upload.wikimedia.org/wikipedia/commons/b/b4/Mardin_1350660_1350692_33_images.jpg", :raise_on_failure=>true, :timeout=>2.0)
 => [9545, 6623]
+FastImage.new("http://stephensykes.com/images/pngimage").content_length
+=> 432
 </code></pre>
 
 h2. Installation

--- a/lib/fastimage.rb
+++ b/lib/fastimage.rb
@@ -48,7 +48,7 @@ require 'pathname'
 require 'zlib'
 
 class FastImage
-  attr_reader :size, :type
+  attr_reader :size, :type, :content_length
 
   attr_reader :bytes_read
 
@@ -251,6 +251,8 @@ class FastImage
           end
         end
       end
+
+      @content_length = res.content_length
 
       parse_packets FiberStream.new(read_fiber)
 

--- a/test/test.rb
+++ b/test/test.rb
@@ -297,4 +297,18 @@ class FastImageTest < Test::Unit::TestCase
   ensure
     %x{rm -f shell_test}
   end
+
+  def test_content_length
+    url = "#{TestUrl}with_content_length.gif"
+    FakeWeb.register_uri(:get, url, :body => File.join(FixturePath, "test.jpg"), :content_length => 52)
+
+    assert_equal 52, FastImage.new(url).content_length
+  end
+
+  def test_content_length_not_provided
+    url = "#{TestUrl}without_content_length.gif"
+    FakeWeb.register_uri(:get, url, :body => File.join(FixturePath, "test.jpg"))
+
+    assert_equal nil, FastImage.new(url).content_length
+  end
 end


### PR DESCRIPTION
Fix #51 allow accessing request header content-length information.