### PR TITLE
Support additional HTTP headers

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -34,6 +34,8 @@ FastImage normally replies will nil if it encounters an error, but you can pass 
 
 FastImage also provides a reader for the content length header provided in HTTP. This may be useful to assess the file size of an image, but do not rely on it exclusively - it will not be present in chunked responses for instance.
 
+FastImage accepts additional HTTP headers. This can be used to set a user agent or referrer which some server require. Pass a :http_header argument to specify headers, e.g., :http_header => {'User-Agent' => 'Fake Browser'}.
+
 h2. Security
 
 As of v1.6.7 FastImage no longer uses openuri to open files, but directly calls File.open. But take care to sanitise the strings passed to FastImage; it will try to read from whatever is passed.
@@ -55,6 +57,8 @@ FastImage.size("http://upload.wikimedia.org/wikipedia/commons/b/b4/Mardin_135066
 => [9545, 6623]
 FastImage.new("http://stephensykes.com/images/pngimage").content_length
 => 432
+FastImage.size("http://stephensykes.com/images/ss.com_x.gif", :http_header => {'User-Agent' => 'Fake Browser'})
+=> [266, 56]
 </code></pre>
 
 h2. Installation


### PR DESCRIPTION
Hi,

I use FastImage to request hosts which require a User-Agent HTTP header. This commit makes it possible to specify additional HTTP headers for each request.

```ruby
FastImage.size("http://example.nowhere/image.jpg", :http_header => {'User-Agent' => 'Fake Browser'})
```

I didnt find a way to write a reasonable test using FakeWeb. It seems like there is no way to differentiate between HTTP headers. Let me know if you know a way.

Regards