### PR TITLE
raise UnknownImageType when file is non-svg xml

### DIFF
--- a/lib/fastimage.rb
+++ b/lib/fastimage.rb
@@ -436,8 +436,14 @@ class FastImage
       else
         raise UnknownImageType
       end
-    when "<?", "<s"
+    when "<s"
       :svg
+    when "<?"
+      if @stream.peek(100).include?("<svg")
+        :svg
+      else
+        raise UnknownImageType
+      end
     else
       raise UnknownImageType
     end

--- a/test/fixtures/test.xml
+++ b/test/fixtures/test.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+</html>

--- a/test/test.rb
+++ b/test/test.rb
@@ -37,7 +37,8 @@ GoodFixtures = {
 
 BadFixtures = [
   "faulty.jpg",
-  "test_rgb.ct"
+  "test_rgb.ct",
+  "test.xml"
 ]
 # man.ico courtesy of http://www.iconseeker.com/search-icon/artists-valley-sample/business-man-blue.html
 # test_rgb.ct courtesy of http://fileformats.archiveteam.org/wiki/Scitex_CT
@@ -119,6 +120,12 @@ class FastImageTest < Test::Unit::TestCase
   def test_should_raise_when_asked_when_image_type_not_known
     assert_raises(FastImage::UnknownImageType) do
       FastImage.size(TestUrl + "test_rgb.ct", :raise_on_failure=>true)
+    end
+  end
+
+  def test_should_raise_unknown_image_typ_when_file_is_non_svg_xml
+    assert_raises(FastImage::UnknownImageType) do
+      FastImage.size(TestUrl + "test.xml", :raise_on_failure=>true)
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/sdsykes/fastimage/issues/55 .

As xml files are not always svg's, this PR adds further verifications to check that it's really a svg file.