### PR TITLE
Add Ruby 2.2.4, 2.3.0 to Travis. Update to 2.1.8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
-  - 2.1.2
+  - 2.1.8
+  - 2.2.4
+  - 2.3.0
+
+sudo: false
 # uncomment this line if your project needs to run something other than `rake`:
 # script: bundle exec rspec spec


### PR DESCRIPTION
Also use containerized builds for Travis CI.

Uses the latests stables of Ruby 2.1.x, 2.2.x and 2.3.x.