### PR TITLE
Always rewind the given IO

### DIFF
--- a/lib/fastimage.rb
+++ b/lib/fastimage.rb
@@ -200,8 +200,6 @@ class FastImage
       end
     end
 
-    uri.rewind if uri.respond_to?(:rewind)
-
     raise SizeNotFound if @options[:raise_on_failure] && @property == :size && !@size
 
   rescue Timeout::Error, SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ECONNRESET,
@@ -219,6 +217,9 @@ class FastImage
         raise ImageFetchFailure
       end
     end
+
+  ensure
+    uri.rewind if uri.respond_to?(:rewind)
 
   end
 

--- a/test/test.rb
+++ b/test/test.rb
@@ -292,6 +292,18 @@ class FastImageTest < Test::Unit::TestCase
     end
   end
 
+  def test_should_rewind_ios
+    string = File.read(File.join(FixturePath, "test.bmp"))
+    stringio = StringIO.new(string)
+    FastImage.type(stringio)
+    assert_equal 0, stringio.pos
+
+    string = File.read(File.join(FixturePath, "test.xml"))
+    stringio = StringIO.new(string)
+    FastImage.type(stringio)
+    assert_equal 0, stringio.pos
+  end
+
   def test_gzipped_file
     url = "http://example.nowhere/#{GzipTestImg}"
     assert_equal([970, 450], FastImage.size(url))


### PR DESCRIPTION
When an error occured when extracting dimensions, rewinding would be skipped and the code would jump straight to "rescue" statements. We want that the IO is always rewinded, even in case of errors.

Note that this doesn't affect the return value of the method, because the return value of a method-level "ensure" is always ignored by Ruby.