### PR TITLE
Enclose README code phrases in Textile code markup

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -19,29 +19,27 @@ You only need supply the uri, and FastImage will do the rest.
 
 h2. Features
 
-Fastimage can also read local (and other) files - anything that is not parseable as a URI will be
-interpreted as a filename, and FastImage will attempt to open it with File#open.
+FastImage can also read local (and other) files - anything that is not parseable as a URI will be interpreted as a filename, and FastImage will attempt to open it with @File#open@.
 
-FastImage will also automatically read from any object that responds to :read - for
-instance an IO object if that is passed instead of a URI.
+FastImage will also automatically read from any object that responds to @:read@ - for instance an IO object if that is passed instead of a URI.
 
 FastImage will follow up to 4 HTTP redirects to get the image.
 
-FastImage will obey the http_proxy setting in your environment to route requests via a proxy. You can also pass a :proxy argument if you want to specify the proxy address in the call.
+FastImage will obey the @http_proxy@ setting in your environment to route requests via a proxy. You can also pass a @:proxy@ argument if you want to specify the proxy address in the call.
 
-You can add a timeout to the request which will limit the request time by passing :timeout => number_of_seconds.
+You can add a timeout to the request which will limit the request time by passing @:timeout => number_of_seconds@.
 
-FastImage normally replies will nil if it encounters an error, but you can pass :raise_on_failure => true to get an exception.
+FastImage normally replies with @nil@ if it encounters an error, but you can pass @:raise_on_failure => true@ to get an exception.
 
 FastImage also provides a reader for the content length header provided in HTTP. This may be useful to assess the file size of an image, but do not rely on it exclusively - it will not be present in chunked responses for instance.
 
-FastImage accepts additional HTTP headers. This can be used to set a user agent or referrer which some servers require. Pass an :http_header argument to specify headers, e.g., :http_header => {'User-Agent' => 'Fake Browser'}.
+FastImage accepts additional HTTP headers. This can be used to set a user agent or referrer which some servers require. Pass an @:http_header@ argument to specify headers, e.g., @:http_header => {'User-Agent' => 'Fake Browser'}@.
 
 FastImage can give you information about the parsed display orientation of an image with Exif data (jpeg or tiff).
 
 h2. Security
 
-As of v1.6.7 FastImage no longer uses openuri to open files, but directly calls File.open. But take care to sanitise the strings passed to FastImage; it will try to read from whatever is passed.
+As of v1.6.7 FastImage no longer uses @openuri@ to open files, but directly calls @File.open@. Take care to sanitise the strings passed to FastImage; it will try to read from whatever is passed.
 
 h2. Examples
 


### PR DESCRIPTION
Originally, this update was to prevent Textile from changing single
quotes into directional quotes in a code snippet under the Features
header.

The snippet pertains to setting additional HTTP headers:

```
:http_header => {'User-Agent' => 'Fake Browser'}
```

To maintain consistency, all code phrases found under the Features
header were wrapped in @ symbols.

A couple minor typos were also corrected.
