### PR TITLE
Make SVG detection more robust

### DIFF
--- a/lib/fastimage.rb
+++ b/lib/fastimage.rb
@@ -449,9 +449,8 @@ class FastImage
       else
         raise UnknownImageType
       end
-    when "<s"
-      :svg
-    when "<?"
+    when "<s", "<?"
+      # Does not handle UTF-16 or other multi-byte encodings
       if @stream.peek(100).include?("<svg")
         :svg
       else

--- a/test/fixtures/test.smil
+++ b/test/fixtures/test.smil
@@ -1,0 +1,13 @@
+<smil><!--The SMIL file must start with a <smil> tag and end with the </smil> closing tag.-->
+   <head> <!-- SMIL file header, specify meta information in the multimedia presentation-->
+                <meta name="author" content="Jane Morales"/>
+                <meta name="title" content="Multimedia My Way"/>
+                <meta name="copyright" content="(c)1998 Jane Morales"/>
+   </head>
+   <body>
+                <seq> <!-- To play clips in sequence, use the <seq> ("sequence") SMIL tag.-->
+                  <audio src="audio/newsong.wav"/>
+                  <audio src="audio/oldsong.snd"/>
+                </seq>
+    </body>
+</smil>

--- a/test/test.rb
+++ b/test/test.rb
@@ -132,6 +132,12 @@ class FastImageTest < Test::Unit::TestCase
     end
   end
 
+  def test_should_raise_unknown_image_typ_when_file_is_smil_xml
+    assert_raises(FastImage::UnknownImageType) do
+      FastImage.size(FixturePath + "/test.smil", :raise_on_failure=>true)
+    end
+  end
+
   def test_should_raise_unknown_image_typ_when_file_is_non_svg_xml
     assert_raises(FastImage::UnknownImageType) do
       FastImage.size(TestUrl + "test.xml", :raise_on_failure=>true)


### PR DESCRIPTION
There are other XML files starting with `<s` so we should always peek a little bit further.

This pull request updates the implementation and adds a test.