### PR TITLE
Improve parse_type UnknownImageType detection

### DIFF
--- a/lib/fastimage.rb
+++ b/lib/fastimage.rb
@@ -442,7 +442,7 @@ class FastImage
   end
 
   def parse_type
-    case @stream.peek(2)
+    parsed_type = case @stream.peek(2)
     when "BM"
       :bmp
     when "GI"
@@ -462,22 +462,14 @@ class FastImage
       when 2 then :cur
       end
     when "RI"
-      if @stream.peek(12)[8..11] == "WEBP"
-        :webp
-      else
-        raise UnknownImageType
-      end
+      :webp if @stream.peek(12)[8..11] == "WEBP"
     when "<s"
       :svg
     when "<?"
-      if @stream.peek(100).include?("<svg")
-        :svg
-      else
-        raise UnknownImageType
-      end
-    else
-      raise UnknownImageType
+      :svg if @stream.peek(100).include?("<svg")
     end
+    
+    parsed_type or raise UnknownImageType
   end
 
   def parse_size_for_ico


### PR DESCRIPTION
In case of 'ice' file type when neither 1 or 2 is found it should raise `UnknownImageType` but it didn't, probably due to the method not being 100% DRY.

This commit fixes both issues at once
