### PR TITLE
Handle protocol relative urls

### DIFF
--- a/lib/fastimage.rb
+++ b/lib/fastimage.rb
@@ -239,7 +239,9 @@ class FastImage
         begin
           newly_parsed_uri = Addressable::URI.parse(res['Location'])
           # The new location may be relative - check for that
-          if newly_parsed_uri.scheme != "http" && newly_parsed_uri.scheme != "https"
+          if protocol_relative_url?(res['Location'])
+            @parsed_uri = newly_parsed_uri.tap { |obj| obj.scheme = @parsed_uri.scheme }
+          elsif newly_parsed_uri.scheme != "http" && newly_parsed_uri.scheme != "https"
             @parsed_uri.path = res['Location']
           else
             @parsed_uri = newly_parsed_uri
@@ -280,6 +282,10 @@ class FastImage
 
       break  # needed to actively quit out of the fetch
     end
+  end
+
+  def protocol_relative_url?(url)
+    url.start_with?("//")
   end
 
   def proxy_uri

--- a/test/test.rb
+++ b/test/test.rb
@@ -232,6 +232,12 @@ class FastImageTest < Test::Unit::TestCase
     assert_equal GoodFixtures[GoodFixtures.keys.first][1], FastImage.size(url, :raise_on_failure=>true)
   end
 
+  def test_should_handle_permanent_redirect_with_protocol_relative_url
+    url = "http://example.nowhere/foo.jpeg"
+    register_redirect(url, "//example.nowhere/" + GoodFixtures.keys.first)
+    assert_equal GoodFixtures[GoodFixtures.keys.first][1], FastImage.size(url, :raise_on_failure=>true)
+  end
+
   def register_redirect(from, to)
     resp = Net::HTTPMovedPermanently.new(1.0, 302, "Moved")
     resp['Location'] = to


### PR DESCRIPTION
Currently fastimage doesn't support redirects with protocol relative urls. Steps to repro the issue - 

```
2.2.1 :001 > require 'fastimage'
 => true
2.2.1 :002 > url = "https://play.vidyard.com/osHCgNMQPWmwNCzcaVmnfW.jpg"
 => "https://play.vidyard.com/osHCgNMQPWmwNCzcaVmnfW.jpg"
2.2.1 :003 > FastImage.type(url)
 => nil
```

Since the "Location" header in the response has a protocol relative url ("//cdn.vidyard.com/thumbnails/obaGtqzifX3Tb_M77d8m-g/e36a970cd907fb19356e10.jpg"), fastimage treats it as a relative url as there is no scheme and it fails to follow the redirect.

According to the first answer and the comments in this [post](http://stackoverflow.com/questions/9646407/two-forward-slashes-in-a-url-src-href-attribute), it seems like protocol relative urls is an accepted standard. I hope you find this PR useful. I'm open to suggestions as well. Thanks.