### PR TITLE
Remove rubygems require from test.rb

### DIFF
--- a/test/test.rb
+++ b/test/test.rb
@@ -1,5 +1,3 @@
-require 'rubygems'
-
 require 'test/unit'
 
 PathHere = File.dirname(__FILE__)


### PR DESCRIPTION
It's not necessary: http://www.rubyinside.com/why-using-require-rubygems-is-wrong-1478.html

One less line of code to maintain :)