### PR TITLE
add frozen_string_literal: true

### DIFF
--- a/lib/fastimage.rb
+++ b/lib/fastimage.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # coding: ASCII-8BIT
 
 # FastImage finds the size or type of an image given its uri.


### PR DESCRIPTION
`frozen_string_literal` is a Ruby 2.3 feature (see https://www.ruby-lang.org/en/news/2015/12/25/ruby-2-3-0-released/ ) to make string literals faster if you  deal them as immutable objects.

Note that this has no effect on pre 2.3.