### PR TITLE
better redirect handling

### DIFF
--- a/lib/fastimage.rb
+++ b/lib/fastimage.rb
@@ -250,15 +250,7 @@ class FastImage
       if res.is_a?(Net::HTTPRedirection) && @redirect_count < 4
         @redirect_count += 1
         begin
-          newly_parsed_uri = URI.parse(res['Location'])
-          # The new location may be relative - check for that
-          if protocol_relative_url?(res['Location'])
-            @parsed_uri = URI.parse("#{@parsed_uri.scheme}:#{res['Location']}")
-          elsif newly_parsed_uri.scheme != "http" && newly_parsed_uri.scheme != "https"
-            @parsed_uri.path = res['Location']
-          else
-            @parsed_uri = newly_parsed_uri
-          end
+          @parsed_uri = URI.join(@parsed_uri, res['Location'])
         rescue URI::InvalidURIError
         else
           fetch_using_http_from_parsed_uri

--- a/test/test.rb
+++ b/test/test.rb
@@ -247,6 +247,12 @@ class FastImageTest < Test::Unit::TestCase
     assert_equal GoodFixtures[GoodFixtures.keys.first][1], FastImage.size(url, :raise_on_failure=>true)
   end
 
+  def test_should_handle_permanent_redirect_with_complex_relative_url
+    register_redirect(TestUrl, "/photo.gne?rb=1&short=Vv4Und")
+    register_redirect("#{TestUrl}photo.gne?rb=1&short=Vv4Und", "/" + GoodFixtures.keys.first)
+    assert_equal GoodFixtures[GoodFixtures.keys.first][1], FastImage.size(TestUrl, :raise_on_failure=>true)
+  end
+
   def register_redirect(from, to)
     resp = Net::HTTPMovedPermanently.new(1.0, 302, "Moved")
     resp['Location'] = to


### PR DESCRIPTION
The URL https://flic.kr/p/Vv4Und redirects as:
```
https://www.flickr.com/photo.gne?short=Vv4Und
https://www.flickr.com/photo.gne?rb=1&short=Vv4Und
https://www.flickr.com/photos/always_praveen/35115848582/
```
and causes
```plain
URI::InvalidComponentError: bad component(expected absolute path component): /photo.gne?rb=1&short=Vv4Und
```