### PR TITLE
Support proxies that require a username and password

### DIFF
--- a/lib/fastimage.rb
+++ b/lib/fastimage.rb
@@ -322,7 +322,7 @@ class FastImage
     proxy = proxy_uri
 
     if proxy
-      @http = Net::HTTP::Proxy(proxy.host, proxy.port).new(@parsed_uri.host, @parsed_uri.port)
+      @http = Net::HTTP::Proxy(proxy.host, proxy.port, proxy.user, proxy.password).new(@parsed_uri.host, @parsed_uri.port)
     else
       @http = Net::HTTP.new(@parsed_uri.host, @parsed_uri.port)
     end


### PR DESCRIPTION
So that the below works:

`FastImage.size("https://pbs.twimg.com/media/DWOxDNiWsAAg46x.jpg", proxy: "https://user:password@proxy.com:1234")`

Thanks for a great gem!

٩( ᐛ )و