### PR TITLE
Use SVG Travis CI badge

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -1,5 +1,5 @@
 !https://img.shields.io/gem/dt/fastimage.svg!:https://rubygems.org/gems/fastimage
-!https://travis-ci.org/sdsykes/fastimage.png?branch=master!:https://travis-ci.org/sdsykes/fastimage
+!https://travis-ci.org/sdsykes/fastimage.svg?branch=master!:https://travis-ci.org/sdsykes/fastimage
 
 h1. FastImage
 


### PR DESCRIPTION
Hey!

I was wondering if Ruby 1.9.3 is really still officially supported since the tests are not being run on these versions since 0dcffe126eb77144a2e96e25981883b74d455cb3.