### PR TITLE
Avoid detecting arbitrary XML as SVG

### DIFF
--- a/lib/fastimage.rb
+++ b/lib/fastimage.rb
@@ -502,7 +502,7 @@ class FastImage
     when "RI"
       :webp if @stream.peek(12)[8..11] == "WEBP"
     when "<s"
-      :svg
+      :svg if @stream.peek(4) == "<svg"
     when /<[?!]/
       # Peek 10 more chars each time, and if end of file is reached just raise
       # unknown. We assume the <svg tag cannot be within 10 chars of the end of

--- a/test/fixtures/test2.xml
+++ b/test/fixtures/test2.xml
@@ -1,0 +1,5 @@
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <foo />
+  </soap:Body>
+</soap:Envelope>

--- a/test/test.rb
+++ b/test/test.rb
@@ -44,6 +44,7 @@ BadFixtures = [
   "faulty.jpg",
   "test_rgb.ct",
   "test.xml",
+  "test2.xml",
   "a.CR2",
   "a.CRW"
 ]
@@ -150,9 +151,11 @@ class FastImageTest < Test::Unit::TestCase
     end
   end
 
-  def test_should_raise_unknown_image_typ_when_file_is_non_svg_xml
-    assert_raises(FastImage::UnknownImageType) do
-      FastImage.size(TestUrl + "test.xml", :raise_on_failure=>true)
+  def test_should_raise_unknown_image_type_when_file_is_non_svg_xml
+    ["test.xml", "test2.xml"].each do |fn|
+      assert_raises(FastImage::UnknownImageType) do
+        FastImage.size(TestUrl + fn, :raise_on_failure=>true)
+      end
     end
   end
 


### PR DESCRIPTION
Testing for files beginning with `<s` isn't enough to determine if a file is a SVG. It should at least start with `<svg` otherwise an XML starting with `<soap:Envelope` will be detected as SVG.