### PR TITLE
Fix handling of redirect response without Location header

### DIFF
--- a/lib/fastimage.rb
+++ b/lib/fastimage.rb
@@ -296,7 +296,10 @@ class FastImage
       if res.is_a?(Net::HTTPRedirection) && @redirect_count < 4
         @redirect_count += 1
         begin
-          @parsed_uri = URI.join(@parsed_uri, escaped_location(res['Location']))
+          location = res['Location']
+          raise ImageFetchFailure if location.nil? || location.empty?
+
+          @parsed_uri = URI.join(@parsed_uri, escaped_location(location))
         rescue URI::InvalidURIError
         else
           fetch_using_http_from_parsed_uri

--- a/test/test.rb
+++ b/test/test.rb
@@ -300,6 +300,13 @@ class FastImageTest < Test::Unit::TestCase
     assert_equal GoodFixtures[GoodFixtures.keys.first][1], FastImage.size(TestUrl, :raise_on_failure=>true)
   end
 
+  def test_should_handle_permanent_redirect_with_missing_location
+    register_redirect(TestUrl, nil)
+    assert_raises(FastImage::ImageFetchFailure) do
+      FastImage.size(TestUrl, :raise_on_failure=>true)
+    end
+  end
+
   def register_redirect(from, to)
     resp = Net::HTTPMovedPermanently.new(1.0, 302, "Moved")
     resp['Location'] = to


### PR DESCRIPTION
Fix ArgumentError thrown when the response for the URL does not contain header `Location`

![image](https://user-images.githubusercontent.com/1018543/84976561-cba54380-b15a-11ea-897a-80335de0c907.png)

Got this when trying to use this gem to check and report invalid images from a long list of image URLs
