### PR TITLE
force_encoding was called on Net::ReadAdapter when url is webmocked

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -132,7 +132,7 @@ h2. Tests
 
 You'll need to @gem install fakeweb@ and possibly also  @gem install test-unit@ to be able to run the tests.
 
-bc.. $ ruby test.rb
+bc.. $ ruby test/test.rb
 Run options:
 
 # Running tests:


### PR DESCRIPTION
1. `new_string = @read_fiber.resume if new_string.is_a? Net::ReadAdapter` is the actual fix.
2. it was hidden by `rescue NoMethodError`
3. it was also hiding the "invalid data uri" test exception
4. another fix: reraising the `UnknownImageType` was destroying the original backtrace/cause