### PR TITLE
Identify SVG files that start with a BOM character

### DIFF
--- a/lib/fastimage.rb
+++ b/lib/fastimage.rb
@@ -562,7 +562,7 @@ class FastImage
       :webp if @stream.peek(12)[8..11] == "WEBP"
     when "<s"
       :svg if @stream.peek(4) == "<svg"
-    when /\s\s|\s<|<[?!]/
+    when /\s\s|\s<|<[?!]/, 0xef.chr + 0xbb.chr
       # Peek 10 more chars each time, and if end of file is reached just raise
       # unknown. We assume the <svg tag cannot be within 10 chars of the end of
       # the file, and is within the first 250 chars.

--- a/test/fixtures/test6.svg
+++ b/test/fixtures/test6.svg
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="450" height="450" viewBox="0 0 450 450" overflow="visible" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <path d='M5,19h9l-1,68h-9z' fill='#e80028'/>
+</svg>

--- a/test/test.rb
+++ b/test/test.rb
@@ -48,6 +48,7 @@ GoodFixtures = {
   "heic/heic-maybebroken.HEIC"=>[:heic,[4032,3024]],
   "heic/heic-single.heic"=>[:heif,[1440,960]],
   "heic/heic-collection.heic"=>[:heif,[1440,960]],
+  "test6.svg" => [:svg, [450, 450]]
 }
 
 BadFixtures = [


### PR DESCRIPTION
We have encountered SVG files that begin with a BOM character.

https://en.wikipedia.org/wiki/Byte_order_mark

If the first two chars are the start of a BOM character, it will fetch additional characters as it attempts to find the opening `<svg` tag (the same as if two spaces are the first chars in the file, etc).