### PR TITLE
Handle SVG files that have extra cruft at the start

### DIFF
--- a/lib/fastimage.rb
+++ b/lib/fastimage.rb
@@ -567,9 +567,9 @@ class FastImage
     when /\s\s|\s<|<[?!]/, 0xef.chr + 0xbb.chr
       # Peek 10 more chars each time, and if end of file is reached just raise
       # unknown. We assume the <svg tag cannot be within 10 chars of the end of
-      # the file, and is within the first 250 chars.
+      # the file, and is within the first 1000 chars.
       begin
-        :svg if (1..25).detect {|n| @stream.peek(10 * n).include?("<svg")}
+        :svg if (1..100).detect {|n| @stream.peek(10 * n).include?("<svg")}
       rescue FiberError
         nil
       end

--- a/test/fixtures/test7.svg
+++ b/test/fixtures/test7.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+	<!ENTITY ns_extend "http://ns.adobe.com/Extensibility/1.0/">
+	<!ENTITY ns_ai "http://ns.adobe.com/AdobeIllustrator/10.0/">
+	<!ENTITY ns_graphs "http://ns.adobe.com/Graphs/1.0/">
+	<!ENTITY ns_vars "http://ns.adobe.com/Variables/1.0/">
+	<!ENTITY ns_imrep "http://ns.adobe.com/ImageReplacement/1.0/">
+	<!ENTITY ns_sfw "http://ns.adobe.com/SaveForWeb/1.0/">
+	<!ENTITY ns_custom "http://ns.adobe.com/GenericCustomNamespace/1.0/">
+	<!ENTITY ns_adobe_xpath "http://ns.adobe.com/XPath/1.0/">
+]>
+<svg version="1.1" id="Layer_1" xmlns:x="&ns_extend;" xmlns:i="&ns_ai;" xmlns:graph="&ns_graphs;"
+	xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	viewBox="0 0 100 100"
+	style="enable-background:new 0 0 113.4 113.4;" xml:space="preserve">
+<switch>
+	<g i:extraneous="self">
+		<g>
+			<g>
+				<circle cx="50" cy="50" r="20" fill="red" />
+			</g>
+		</g>
+	</g>
+</switch>
+</svg>

--- a/test/test.rb
+++ b/test/test.rb
@@ -40,6 +40,7 @@ GoodFixtures = {
   "test3.svg" => [:svg, [255, 48]],
   "test4.svg" => [:svg, [271, 271]],
   "test5.svg" => [:svg, [255, 48]],
+  "test7.svg" => [:svg, [100, 100]],
   "orient_6.jpg"=>[:jpeg, [1250,2500]],
   "heic/test.heic"=>[:heic, [700,476]],
   "heic/heic-empty.heic"=>[:heic, [3992,2992]],


### PR DESCRIPTION
At least one older version of Adobe Illustrator adds a bunch of XML entity tags at the start of the file, meaning that the existing check to see if a file is an SVG gives up before finding the `svg` tag