### PR TITLE
 Add base64 as a dependency explicitly for Ruby 3.4.0 support

### DIFF
--- a/fastimage.gemspec
+++ b/fastimage.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.6}
   s.summary = %q{FastImage - Image info fast}
+  s.add_dependency 'base64', '~> 0.2.0'
   s.add_development_dependency 'fakeweb-fi', '~> 1.3'
   # Note rake 11 drops support for ruby 1.9.2
   s.add_development_dependency('rake', ">= 10.5")


### PR DESCRIPTION
## Context

base64 is no longer the default gem from Ruby 3.4
https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/

On Ruby 3.3, we could see the warning:

```ruby
warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec.
```

From Ruby 3.4, we will get the error:

```ruby
Failure/Error: require 'base64'

LoadError:
  cannot load such file -- base64
```

## Changes

add `base64` gem as a dependency to gemspec