### PR TITLE
Fix HTML with inline SVG being incorrectly detected as SVG

### DIFF
--- a/lib/fastimage/fastimage_parsing/type_parser.rb
+++ b/lib/fastimage/fastimage_parsing/type_parser.rb
@@ -57,7 +57,12 @@ module FastImageParsing
         # unknown. We assume the <svg tag cannot be within 10 chars of the end of
         # the file, and is within the first 1000 chars.
         begin
-          :svg if (1..100).detect {|n| @stream.peek(10 * n).include?("<svg")}
+          :svg if (1..100).any? { |n|
+            peeked = @stream.peek(10 * n)
+            svg_index = peeked.index("<svg")
+            html_index = peeked.index(/<html/i)
+            svg_index && (!html_index || svg_index < html_index)
+          }
         rescue FiberError, FastImage::CannotParseImage
           nil
         end

--- a/test/fixtures/test8.html
+++ b/test/fixtures/test8.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><title>Test</title></head>
+<body>
+  <svg viewBox="0 0 100 100"><rect width="50" height="50"/></svg>
+</body>
+</html>

--- a/test/test.rb
+++ b/test/test.rb
@@ -196,6 +196,12 @@ class FastImageTest < Test::Unit::TestCase
     end
   end
 
+  def test_should_raise_unknown_image_type_when_file_is_html_with_inline_svg
+    assert_raises(FastImage::UnknownImageType) do
+      FastImage.size(File.join(FixturePath, "test8.html"), :raise_on_failure=>true)
+    end
+  end
+
   def test_should_raise_unknown_image_type_when_file_is_non_svg_xml
     ["test.xml", "test2.xml"].each do |fn|
       assert_raises(FastImage::UnknownImageType) do


### PR DESCRIPTION
## Summary
- HTML documents containing inline `<svg>` elements were misidentified as SVG images
- The type parser now checks that `<html>` does not appear before `<svg>` in the peeked content, correctly rejecting HTML files
- Added test case with a minimal HTML fixture containing an inline SVG

## Test plan
- [x] New test `test_should_raise_unknown_image_type_when_file_is_html_with_inline_svg` passes
- [x] All existing SVG tests continue to pass (all preamble variants: `<?xml?>`, `<!DOCTYPE svg>`, direct `<svg>`, leading whitespace, BOM)
- [x] SVG with `<foreignObject>` containing `<html>` still correctly detected as SVG

🤖 Generated with [Claude Code](https://claude.com/claude-code)