### PR TITLE
Replace external Wikipedia dependency in tests with local servers

### DIFF
--- a/fastimage.gemspec
+++ b/fastimage.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake', ">= 10.5")
   s.add_development_dependency('rdoc')
   s.add_development_dependency('test-unit')
+  s.add_development_dependency('webrick')
 
   s.licenses = ['MIT']
 end

--- a/test/https_server.rb
+++ b/test/https_server.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+require 'webrick'
+require 'webrick/https'
+require 'openssl'
+
+# A local HTTPS server with a self-signed certificate.
+# Used to verify that FastImage handles SSL connections.
+class HTTPSServer
+  def initialize(replies)
+    @replies = replies
+  end
+
+  def open
+    key = OpenSSL::PKey::RSA.new(2048)
+    cert = OpenSSL::X509::Certificate.new
+    cert.subject = cert.issuer = OpenSSL::X509::Name.parse("/CN=localhost")
+    cert.not_before = Time.now
+    cert.not_after = Time.now + 600
+    cert.public_key = key.public_key
+    cert.serial = 1
+    cert.sign(key, OpenSSL::Digest::SHA256.new)
+
+    server = WEBrick::HTTPServer.new(
+      Port: 0,
+      SSLEnable: true,
+      SSLCertificate: cert,
+      SSLPrivateKey: key,
+      Logger: WEBrick::Log.new("/dev/null"),
+      AccessLog: []
+    )
+
+    @replies.each do |path, (content_type, body)|
+      server.mount_proc(path) do |_req, res|
+        res['Content-Type'] = content_type
+        res.body = body
+      end
+    end
+
+    thread = Thread.new { server.start }
+
+    begin
+      yield server.config[:Port]
+    ensure
+      server.shutdown
+      thread.join
+    end
+  end
+end

--- a/test/slow_server.rb
+++ b/test/slow_server.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+require 'socket'
+
+# A raw TCP server that sends an image immediately, then drip-feeds
+# padding bytes with long delays. Used to verify that FastImage reads
+# only the minimum bytes needed from the response.
+class SlowServer
+  def initialize(image_path)
+    @image_data = File.binread(image_path)
+  end
+
+  def open
+    tcp_server = TCPServer.new("127.0.0.1", 0)
+
+    thread = Thread.new do
+      loop do
+        client = tcp_server.accept rescue break
+        Thread.new(client) do |c|
+          begin
+            c.gets("\r\n\r\n")
+            total_size = @image_data.bytesize + 5_000_000
+            c.write "HTTP/1.1 200 OK\r\nContent-Type: image/jpeg\r\nContent-Length: #{total_size}\r\n\r\n"
+            c.write @image_data
+            100.times do
+              sleep 0.5
+              c.write("\x00" * 1024)
+            end
+          rescue
+          ensure
+            c.close
+          end
+        end
+      end
+    end
+
+    begin
+      yield tcp_server.addr[1]
+    ensure
+      tcp_server.close
+      thread.join(1)
+    end
+  end
+end

--- a/test/test.rb
+++ b/test/test.rb
@@ -5,6 +5,8 @@ $LOAD_PATH.unshift File.join(PathHere, "..", "lib")
 
 require 'fastimage'
 require 'fakeweb'
+require_relative 'slow_server'
+require_relative 'https_server'
 
 FixturePath = File.join(PathHere, "fixtures")
 
@@ -77,15 +79,6 @@ BadFixtures = [
 # test.cur courtesy of http://mimidestino.deviantart.com/art/Clash-Of-Clans-Dragon-Cursor-s-Punteros-489070897
 
 TestUrl = "http://example.nowhere/"
-
-# this image fetch allows me to really test that fastimage is truly fast
-# but it's not ideal relying on external resources and connectivity speed
-LargeImage = "https://upload.wikimedia.org/wikipedia/commons/b/b4/Mardin_1350660_1350692_33_images.jpg"
-LargeImageInfo = [:jpeg, [9545, 6623]]
-LargeImageFetchLimit = 2  # seconds
-
-HTTPSImage = "https://upload.wikimedia.org/wikipedia/commons/b/b4/Mardin_1350660_1350692_33_images.jpg"
-HTTPSImageInfo = [:jpeg, [9545, 6623]]
 
 DataUriImage = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAABCAYAAAD0In+KAAAAD0lEQVR42mNk+M9QzwAEAAmGAYCF+yOnAAAAAElFTkSuQmCC"
 DataUriImageInfo = [:png, [2, 1]]
@@ -352,16 +345,19 @@ class FastImageTest < Test::Unit::TestCase
   end
 
   def test_should_fetch_info_of_large_image_faster_than_downloading_the_whole_thing
-    time = Time.now
-    size = FastImage.size(LargeImage)
-    size_time = Time.now
-    assert size_time - time < LargeImageFetchLimit
-    assert_equal LargeImageInfo[1], size
-    time = Time.now
-    type = FastImage.type(LargeImage)
-    type_time = Time.now
-    assert type_time - time < LargeImageFetchLimit
-    assert_equal LargeImageInfo[0], type
+    SlowServer.new(File.join(FixturePath, "test.jpg")).open do |port|
+      url = "http://127.0.0.1:#{port}/large.jpg"
+
+      time = Time.now
+      size = FastImage.size(url)
+      assert Time.now - time < 2, "FastImage.size took too long, likely reading the entire body"
+      assert_equal GoodFixtures["test.jpg"][1], size
+
+      time = Time.now
+      type = FastImage.type(url)
+      assert Time.now - time < 2, "FastImage.type took too long, likely reading the entire body"
+      assert_equal GoodFixtures["test.jpg"][0], type
+    end
   end
 
   # This test doesn't actually test the proxy function, but at least
@@ -384,8 +380,14 @@ class FastImageTest < Test::Unit::TestCase
   end
 
   def test_should_handle_https_image
-    size = FastImage.size(HTTPSImage)
-    assert_equal HTTPSImageInfo[1], size
+    replies = {
+      "/test.jpg" => ["image/jpeg", File.binread(File.join(FixturePath, "test.jpg"))]
+    }
+
+    HTTPSServer.new(replies).open do |port|
+      size = FastImage.size("https://localhost:#{port}/test.jpg")
+      assert_equal GoodFixtures["test.jpg"][1], size
+    end
   end
 
   require 'pathname'
@@ -446,7 +448,7 @@ class FastImageTest < Test::Unit::TestCase
     FakeWeb.register_uri(:get, url, :body => File.join(FixturePath, "test.jpg"), :content_length => 52)
 
     assert_equal 52, FastImage.new(url).content_length
-    
+
     assert_equal 322, FastImage.new(File.join(FixturePath, "test.png")).content_length
     assert_equal 322, FastImage.new(Pathname.new(File.join(FixturePath, "test.png"))).content_length
 
@@ -510,17 +512,17 @@ class FastImageTest < Test::Unit::TestCase
       FastImage.size(TestUrl + "a.CRW", :raise_on_failure=>true)
     end
   end
-  
+
   def test_returns_nil_when_uri_is_nil
     assert_equal nil, FastImage.size(nil)
   end
-  
+
   def test_raises_when_uri_is_nil_and_raise_on_failure_is_set
     assert_raises(FastImage::BadImageURI) do
       FastImage.size(nil, :raise_on_failure => true)
     end
   end
-  
+
   def test_width
     assert_equal 30, FastImage.new(TestUrl + "test.png").width
     assert_equal nil, FastImage.new(TestUrl + "does_not_exist").width
@@ -530,13 +532,13 @@ class FastImageTest < Test::Unit::TestCase
     assert_equal 20, FastImage.new(TestUrl + "test.png").height
     assert_equal nil, FastImage.new(TestUrl + "does_not_exist").height
   end
-  
+
   def test_content_length_after_size
     fi = FastImage.new(File.join(FixturePath, "test.png"))
     fi.size
     assert_equal 322, fi.content_length
   end
-  
+
   def test_unknown_protocol
     FakeWeb.register_uri(:get, "http://example.com/test", body: "", location: "hhttp://example.com", :status => 301)
     assert_nil FastImage.size("http://example.com/test")


### PR DESCRIPTION
## Summary
- The HTTPS and large-image tests relied on a live Wikipedia URL, causing flaky failures due to HTTP 429 rate limiting
- Replaced with two local test servers:
  - **SlowServer** (raw TCP): sends JPEG header immediately then drip-feeds padding bytes with 0.5s delays, verifying FastImage reads only the minimum bytes needed rather than downloading the entire body
  - **HTTPSServer** (WEBrick + self-signed cert): exercises the real SSL codepath (`use_ssl`, `verify_mode`, etc.) without depending on external services
- Added `webrick` as a dev dependency (needed for the HTTPS server)
- Removed redundant constants (`LargeImage`, `LargeImageInfo`, `LargeImageFetchLimit`, `HTTPSImage`, `HTTPSImageInfo`) in favor of referencing `GoodFixtures` directly

## Test plan
- [x] All 60 tests pass locally
- [x] No external network dependencies remain in the test suite (except `test_should_raise_when_asked_to_when_file_does_not_exist` and `test_should_work_with_domains_with_underscores`)
- [x] HTTPS test exercises real SSL handshake with self-signed certificate
- [x] Large image test confirms FastImage returns in <2s despite server needing 50+ seconds to send full body

🤖 Generated with [Claude Code](https://claude.com/claude-code)