### PR TITLE
Update Ruby test runner to drop unsupported versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       - run: bundle exec rake
   test_old_ruby:
     name: Test (Ruby ${{ matrix.ruby }})
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,20 +26,3 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - run: bundle exec rake
-  test_old_ruby:
-    name: Test (Ruby ${{ matrix.ruby }})
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby:
-          - '2.0'
-          - '2.1'
-          - '2.2'
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
-      - run: bundle exec rake

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
           - '3.2'
           - '3.3'
           - '3.4'
+          - '4.0'
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ puts Benchmark.measure {p FastImage.size(uri)}
   0.163443   0.214301   0.377744 (  2.880414)
 ```
 
+## Compatibility
+
+FastImage requires Ruby 1.9.2 or later. It is tested on CI with Ruby 2.3 through 4.0.
+
 ## Tests
 
 You'll need to bundle, or `gem install fakeweb` and possibly also  `gem install test-unit` to be able to run the tests.


### PR DESCRIPTION
Upgrading runner to ubuntu 22.04 did not work for ruby 2.2, so instead let's drop those old versions from the tests. Note that the required_ruby_version in the gemspec has not been updated, but we should at some point.