### PR TITLE
Release v2.4.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+Version 2.4.1
+
+09-Mar-2026
+
+- FIX: HTML with inline SVG being incorrectly detected as SVG
+- IMPROVED: Replace external test dependencies with local servers
+
 Version 2.4.0
 
 03-Jan-2025

--- a/lib/fastimage/version.rb
+++ b/lib/fastimage/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class FastImage
-  VERSION = '2.4.0'
+  VERSION = '2.4.1'
 end


### PR DESCRIPTION
## Summary
- Bump version to 2.4.1
- Update CHANGELOG with new entries:
  - FIX: HTML with inline SVG being incorrectly detected as SVG
  - IMPROVED: Replace external test dependencies with local servers

## Test plan
- [ ] `bundle exec rake` passes
- [ ] `gem build fastimage.gemspec` succeeds
- [ ] Verify CHANGELOG formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)